### PR TITLE
GIL management

### DIFF
--- a/applications/plugins/Compliant/initCompliant.cpp
+++ b/applications/plugins/Compliant/initCompliant.cpp
@@ -55,6 +55,8 @@ void initExternalModule()
     static bool first = true;
     if (first)
     {
+        simulation::PythonEnvironment::gil lock(__func__);
+        
         first = false;
 
         component::collision::CompliantSolverMerger::add();

--- a/applications/plugins/Compliant/initCompliant.cpp
+++ b/applications/plugins/Compliant/initCompliant.cpp
@@ -55,8 +55,6 @@ void initExternalModule()
     static bool first = true;
     if (first)
     {
-        simulation::PythonEnvironment::gil lock(__func__);
-        
         first = false;
 
         component::collision::CompliantSolverMerger::add();
@@ -68,6 +66,7 @@ void initExternalModule()
         // adding _Compliant python module
         if( PythonFactory::s_sofaPythonModule ) // add the module only if the Sofa module exists (SofaPython is loaded)
         {
+            simulation::PythonEnvironment::gil lock(__func__);
             static PyObject *s__CompliantPythonModule = SP_INIT_MODULE(_Compliant);
 
             // adding more bindings to the _Compliant module

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -368,6 +368,28 @@ void PythonEnvironment::excludeModuleFromReload( const std::string& moduleName )
 }
 
 
+
+static PyGILState_Release lock() {
+    // this ensures that we start with no active thread before locking the
+    // gil. the first gil should be taken right after the python initializer is
+    // initialized.
+    static const PyThreadState* init = PyEval_SaveThread(); (void) init;
+    return PyGILState_Ensure();
+}
+
+
+PythonEnvironment::gil::gil()
+    : state(lock()) {
+    
+}
+
+
+PythonEnvironment::gil::~gil() {
+    PyGILState_Release(state);
+}
+
+
+
 } // namespace simulation
 
 } // namespace sofa

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -143,7 +143,11 @@ void PythonEnvironment::Init()
 
 void PythonEnvironment::Release()
 {
+    if ( !Py_IsInitialized() ) return;
+    
     // Finish the Python Interpreter
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
     Py_Finalize();
 }
 

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -418,14 +418,32 @@ PythonEnvironment::gil::gil(const char* trace)
 
 PythonEnvironment::gil::~gil() {
 
+    PyGILState_Release(state);
+    
     if(debug_gil && trace) {
-        std::clog << "<< " << trace << " releases the gil" << std::endl;
+        std::clog << "<< " << trace << " released the gil" << std::endl;
     }
     
-    PyGILState_Release(state);
 }
 
 
+
+PythonEnvironment::no_gil::no_gil(const char* trace)
+    : state(PyEval_SaveThread()),
+      trace(trace) {
+    if(debug_gil && trace) {
+        std::clog << ">> " << trace << " temporarily released the gil" << std::endl;
+    }
+}
+
+PythonEnvironment::no_gil::~no_gil() {
+
+    if(debug_gil && trace) {
+        std::clog << "<< " << trace << " wants to reacquire the gil" << std::endl;
+    }
+    
+    PyEval_RestoreThread(state);
+}
 
 } // namespace simulation
 

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -153,8 +153,10 @@ void PythonEnvironment::Release()
 
     // Finish the Python Interpreter
     // obviously can't use raii here
-    PyGILState_Ensure();    
-    Py_Finalize();
+    if( Py_IsInitialized() ) {
+        PyGILState_Ensure();    
+        Py_Finalize();
+    }
 }
 
 void PythonEnvironment::addPythonModulePath(const std::string& path)

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -45,7 +45,7 @@ namespace simulation
 
 PyMODINIT_FUNC initModulesHelper(const std::string& name, PyMethodDef* methodDef)
 {
-    gil lock;
+    PythonEnvironment::gil lock;
     Py_InitModule(name.c_str(), methodDef);
 }
 
@@ -388,7 +388,7 @@ void PythonEnvironment::excludeModuleFromReload( const std::string& moduleName )
 
 
 
-static PyGILState_Release lock() {
+static PyGILState_STATE lock() {
     // this ensures that we start with no active thread before first locking the
     // gil: this way the last gil unlock lets python threads to run (otherwise
     // the main thread still holds the gil, preventing python threads to run

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -154,8 +154,9 @@ void PythonEnvironment::Release()
     gil lock(__func__);
     
     // Finish the Python Interpreter
-    PyGILState_STATE gstate;
-    gstate = PyGILState_Ensure();
+
+    // obviously can't use raii here
+    PyGILState_Ensure();    
     Py_Finalize();
 }
 

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -151,10 +151,7 @@ void PythonEnvironment::Release()
 {
     if ( !Py_IsInitialized() ) return;
 
-    gil lock(__func__);
-    
     // Finish the Python Interpreter
-
     // obviously can't use raii here
     PyGILState_Ensure();    
     Py_Finalize();

--- a/applications/plugins/SofaPython/PythonEnvironment.cpp
+++ b/applications/plugins/SofaPython/PythonEnvironment.cpp
@@ -294,34 +294,25 @@ bool PythonEnvironment::runFile( const char *filename, const std::vector<std::st
     std::string dir = sofa::helper::system::SetDirectory::GetParentDir(filename);
     std::string bareFilename = sofa::helper::system::SetDirectory::GetFileNameWithoutExtension(filename);
 
-    if(!arguments.empty())
-    {
-        char**argv = new char*[arguments.size()+1];
-        argv[0] = new char[bareFilename.size()+1];
-        strcpy( argv[0], bareFilename.c_str() );
-        for( size_t i=0 ; i<arguments.size() ; ++i )
-        {
-            argv[i+1] = new char[arguments[i].size()+1];
-            strcpy( argv[i+1], arguments[i].c_str() );
+    if(arguments.size()) {
+        std::vector<const char*> argv;
+
+        // not sure we want this
+        argv.push_back(bareFilename.c_str());
+        
+        for(const std::string& arg : arguments) {
+            argv.push_back(arg.c_str());
         }
 
-        Py_SetProgramName(argv[0]); // TODO check what it is doing exactly
-        PySys_SetArgv(arguments.size()+1, argv);
-
-        for( size_t i=0 ; i<arguments.size()+1 ; ++i )
-        {
-            delete [] argv[i];
-        }
-        delete [] argv;
+        // TODO check what it is doing exactly        
+        Py_SetProgramName((char*) argv[0]);
+        PySys_SetArgv(argv.size(), (char**) argv.data());
     }
 
     // Load the scene script
-    char* pythonFilename = strdup(filename);
-    PyObject* scriptPyFile = PyFile_FromString(pythonFilename, (char*)("r"));
-    free(pythonFilename);
-
-    if( !scriptPyFile )
-    {
+    PyObject* scriptPyFile = PyFile_FromString((char*)filename, (char*)("r"));
+    
+    if( !scriptPyFile ) {
         SP_MESSAGE_ERROR("cannot open file:" << filename)
         PyErr_Print();
         return false;
@@ -331,9 +322,10 @@ bool PythonEnvironment::runFile( const char *filename, const std::vector<std::st
 
     std::string backupFileName;
     PyObject* backupFileObject = PyDict_GetItemString(pDict, "__file__");
-    if(backupFileObject)
+    if(backupFileObject) {
         backupFileName = PyString_AsString(backupFileObject);
-
+    }
+    
     PyObject* newFileObject = PyString_FromString(filename);
     PyDict_SetItemString(pDict, "__file__", newFileObject);
 

--- a/applications/plugins/SofaPython/PythonEnvironment.h
+++ b/applications/plugins/SofaPython/PythonEnvironment.h
@@ -86,6 +86,19 @@ public:
     };
 
     struct system_exit : std::exception { };
+
+    /// use this RAII-class to ensure the gil is properly acquired and released
+    /// in a scope. these should be surrounding any python code called from c++,
+    /// i.e. in all the methods in PythonEnvironment and all the methods in
+    /// PythonScriptController.
+    class gil {
+        const PyGILState_STATE state;
+    public:
+        gil();
+        ~gil();
+    };
+    
+
 };
 
 

--- a/applications/plugins/SofaPython/PythonEnvironment.h
+++ b/applications/plugins/SofaPython/PythonEnvironment.h
@@ -93,8 +93,9 @@ public:
     /// PythonScriptController.
     class gil {
         const PyGILState_STATE state;
+        const char* trace;
     public:
-        gil();
+        gil(const char* trace = nullptr);
         ~gil();
     };
     

--- a/applications/plugins/SofaPython/PythonEnvironment.h
+++ b/applications/plugins/SofaPython/PythonEnvironment.h
@@ -93,10 +93,19 @@ public:
     /// PythonScriptController.
     class gil {
         const PyGILState_STATE state;
-        const char* trace;
+        const char* const trace;
     public:
         gil(const char* trace = nullptr);
         ~gil();
+    };
+
+
+    class no_gil {
+        PyThreadState* const state;
+        const char* const trace;
+    public:
+        no_gil(const char* trace = nullptr);
+        ~no_gil();
     };
     
 

--- a/applications/plugins/SofaPython/PythonEnvironment.h
+++ b/applications/plugins/SofaPython/PythonEnvironment.h
@@ -91,7 +91,7 @@ public:
     /// in a scope. these should be surrounding any python code called from c++,
     /// i.e. in all the methods in PythonEnvironment and all the methods in
     /// PythonScriptController.
-    class gil {
+    class SOFA_SOFAPYTHON_API gil {
         const PyGILState_STATE state;
         const char* const trace;
     public:
@@ -100,7 +100,7 @@ public:
     };
 
 
-    class no_gil {
+    class SOFA_SOFAPYTHON_API no_gil {
         PyThreadState* const state;
         const char* const trace;
     public:

--- a/applications/plugins/SofaPython/PythonMainScriptController.cpp
+++ b/applications/plugins/SofaPython/PythonMainScriptController.cpp
@@ -119,8 +119,10 @@ void PythonMainScriptController::loadScript()
 
 }
 
-void PythonMainScriptController::script_onIdleEvent(const IdleEvent* /*event*/)
+void PythonMainScriptController::script_onIdleEvent(const IdleEvent* event)
 {
+    // there's no such thing as a macro being better than something ;-)    
+    (void) event;
     PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_onIdle)
 }

--- a/applications/plugins/SofaPython/PythonMainScriptController.cpp
+++ b/applications/plugins/SofaPython/PythonMainScriptController.cpp
@@ -74,6 +74,7 @@ PythonMainScriptController::PythonMainScriptController(const char* filename)
 
 void PythonMainScriptController::loadScript()
 {
+    PythonEnvironment::gil lock(__func__);
     if(!PythonEnvironment::runFile(m_filename))
     {
         SP_MESSAGE_ERROR( getName() << " object - "<<m_filename<<" script load error." )
@@ -118,24 +119,27 @@ void PythonMainScriptController::loadScript()
 
 }
 
-void PythonMainScriptController::script_onIdleEvent(const IdleEvent* event)
+void PythonMainScriptController::script_onIdleEvent(const IdleEvent* /*event*/)
 {
-    SOFA_UNUSED(event) ;
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_onIdle)
 }
 
 void PythonMainScriptController::script_onLoaded(sofa::simulation::Node *node)
 {
+    PythonEnvironment::gil lock(__func__);        
     SP_CALL_MODULEFUNC(m_Func_onLoaded,"(O)",sofa::PythonFactory::toPython(node))
 }
 
 void PythonMainScriptController::script_createGraph(sofa::simulation::Node *node)
 {
+    PythonEnvironment::gil lock(__func__);            
     SP_CALL_MODULEFUNC(m_Func_createGraph,"(O)",sofa::PythonFactory::toPython(node))
 }
 
 void PythonMainScriptController::script_initGraph(sofa::simulation::Node *node)
 {
+    PythonEnvironment::gil lock(__func__);            
     // no ScriptController::parse for a PythonMainScriptController
     // so call these functions here
     script_onLoaded( down_cast<simulation::Node>(getContext()) );
@@ -146,17 +150,20 @@ void PythonMainScriptController::script_initGraph(sofa::simulation::Node *node)
 
 void PythonMainScriptController::script_bwdInitGraph(sofa::simulation::Node *node)
 {
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC(m_Func_bwdInitGraph,"(O)",sofa::PythonFactory::toPython(node))
 }
 
 bool PythonMainScriptController::script_onKeyPressed(const char c)
 {
+    PythonEnvironment::gil lock(__func__);    
     bool b = false;
     SP_CALL_MODULEBOOLFUNC(m_Func_onKeyPressed,"(c)", c);
     return b;
 }
 bool PythonMainScriptController::script_onKeyReleased(const char c)
 {
+    PythonEnvironment::gil lock(__func__);    
     bool b = false;
     SP_CALL_MODULEBOOLFUNC(m_Func_onKeyReleased,"(c)", c);
     return b;
@@ -164,57 +171,67 @@ bool PythonMainScriptController::script_onKeyReleased(const char c)
 
 void PythonMainScriptController::script_onMouseButtonLeft(const int posX,const int posY,const bool pressed)
 {
+    PythonEnvironment::gil lock(__func__);    
     PyObject *pyPressed = pressed? Py_True : Py_False;
     SP_CALL_MODULEFUNC(m_Func_onMouseButtonLeft,"(iiO)", posX,posY,pyPressed);
 }
 
 void PythonMainScriptController::script_onMouseButtonRight(const int posX,const int posY,const bool pressed)
 {
+    PythonEnvironment::gil lock(__func__);    
     PyObject *pyPressed = pressed? Py_True : Py_False;
     SP_CALL_MODULEFUNC(m_Func_onMouseButtonRight,"(iiO)", posX,posY,pyPressed);
 }
 
 void PythonMainScriptController::script_onMouseButtonMiddle(const int posX,const int posY,const bool pressed)
 {
+    PythonEnvironment::gil lock(__func__);    
     PyObject *pyPressed = pressed? Py_True : Py_False;
     SP_CALL_MODULEFUNC(m_Func_onMouseButtonMiddle,"(iiO)", posX,posY,pyPressed);
 }
 
 void PythonMainScriptController::script_onMouseWheel(const int posX,const int posY,const int delta)
 {
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC(m_Func_onMouseWheel,"(iii)", posX,posY,delta);
 }
 
 
 void PythonMainScriptController::script_onBeginAnimationStep(const double dt)
 {
+    PythonEnvironment::gil lock(__func__);    
     helper::ScopedAdvancedTimer advancedTimer("PythonMainScriptController_AnimationStep");
     SP_CALL_MODULEFUNC(m_Func_onBeginAnimationStep,"(d)", dt)
 }
 
 void PythonMainScriptController::script_onEndAnimationStep(const double dt)
 {
+    PythonEnvironment::gil lock(__func__);    
     helper::ScopedAdvancedTimer advancedTimer("PythonMainScriptController_AnimationStep");
     SP_CALL_MODULEFUNC(m_Func_onEndAnimationStep,"(d)", dt)
 }
 
 void PythonMainScriptController::script_storeResetState()
 {
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_storeResetState)
 }
 
 void PythonMainScriptController::script_reset()
 {
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_reset)
 }
 
 void PythonMainScriptController::script_cleanup()
 {
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_cleanup)
 }
 
 void PythonMainScriptController::script_onGUIEvent(const char* controlID, const char* valueName, const char* value)
 {
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC(m_Func_onGUIEvent,"(sss)",controlID,valueName,value)
 }
 
@@ -223,11 +240,13 @@ void PythonMainScriptController::script_onScriptEvent(ScriptEvent* event)
     helper::ScopedAdvancedTimer advancedTimer( (std::string("PythonMainScriptController_Event_")+this->getName()).c_str() );
 
     PythonScriptEvent *pyEvent = static_cast<PythonScriptEvent*>(event);
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC(m_Func_onScriptEvent,"(OsO)",sofa::PythonFactory::toPython(pyEvent->getSender().get()),const_cast<char*>(pyEvent->getEventName().c_str()),pyEvent->getUserData())
 }
 
 void PythonMainScriptController::script_draw(const VisualParams*)
 {
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_draw)
 }
 

--- a/applications/plugins/SofaPython/PythonScriptController.cpp
+++ b/applications/plugins/SofaPython/PythonScriptController.cpp
@@ -144,7 +144,7 @@ PythonScriptController::~PythonScriptController()
 
 
 void PythonScriptController::setInstance(PyObject* instance) {
-    PythonEnvironment::gil lock;
+    PythonEnvironment::gil lock(__func__);
     
     // "trust me i'm an engineer"
     if( m_ScriptControllerInstance ) {
@@ -189,7 +189,7 @@ void PythonScriptController::refreshBinding()
 
 bool PythonScriptController::isDerivedFrom(const std::string& name, const std::string& module)
 {
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     PyObject* moduleDict = PyModule_GetDict(PyImport_AddModule(module.c_str()));
     PyObject* controllerClass = PyDict_GetItemString(moduleDict, name.c_str());
 
@@ -198,7 +198,7 @@ bool PythonScriptController::isDerivedFrom(const std::string& name, const std::s
 
 void PythonScriptController::loadScript()
 {
-    PythonEnvironment::gil lock;        
+    PythonEnvironment::gil lock(__func__);        
     if(m_doAutoReload.getValue())
     {
         FileMonitor::addFile(m_filename.getFullPath(), m_filelistener) ;
@@ -255,7 +255,7 @@ void PythonScriptController::script_onIdleEvent(const IdleEvent* /*event*/)
     FileMonitor::updates(0);
 
     {
-        PythonEnvironment::gil lock;
+        PythonEnvironment::gil lock(__func__);
         SP_CALL_MODULEFUNC_NOPARAM(m_Func_onIdle) ;
     }
 
@@ -266,7 +266,7 @@ void PythonScriptController::script_onIdleEvent(const IdleEvent* /*event*/)
 
 void PythonScriptController::script_onLoaded(Node *node)
 {
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC(m_Func_onLoaded, "(O)", sofa::PythonFactory::toPython(node))
 }
 
@@ -288,19 +288,19 @@ void PythonScriptController::parse(sofa::core::objectmodel::BaseObjectDescriptio
 
 void PythonScriptController::script_createGraph(Node *node)
 {
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC(m_Func_createGraph, "(O)", sofa::PythonFactory::toPython(node))
 }
 
 void PythonScriptController::script_initGraph(Node *node)
 {
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC(m_Func_initGraph, "(O)", sofa::PythonFactory::toPython(node))
 }
 
 void PythonScriptController::script_bwdInitGraph(Node *node)
 {
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC(m_Func_bwdInitGraph, "(O)", sofa::PythonFactory::toPython(node))
 }
 
@@ -309,7 +309,7 @@ bool PythonScriptController::script_onKeyPressed(const char c)
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
                                                "PythonScriptController_onKeyPressed", this);
     bool b = false;
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEBOOLFUNC(m_Func_onKeyPressed,"(c)", c);
     return b;
 }
@@ -320,7 +320,7 @@ bool PythonScriptController::script_onKeyReleased(const char c)
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
                                                "PythonScriptController_onKeyReleased", this);
     bool b = false;
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEBOOLFUNC(m_Func_onKeyReleased,"(c)", c);
     return b;
 }
@@ -329,7 +329,7 @@ void PythonScriptController::script_onMouseButtonLeft(const int posX,const int p
 {
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
                                                "PythonScriptController_onMouseButtonLeft",this);
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     PyObject *pyPressed = pressed? Py_True : Py_False;
     SP_CALL_MODULEFUNC(m_Func_onMouseButtonLeft, "(iiO)", posX,posY,pyPressed)
 }
@@ -338,7 +338,7 @@ void PythonScriptController::script_onMouseButtonRight(const int posX,const int 
 {
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
                                                "PythonScriptController_onMouseButtonRight", this);
-    PythonEnvironment::gil lock;
+    PythonEnvironment::gil lock(__func__);
     PyObject *pyPressed = pressed? Py_True : Py_False;
     SP_CALL_MODULEFUNC(m_Func_onMouseButtonRight, "(iiO)", posX,posY,pyPressed)
 }
@@ -347,7 +347,7 @@ void PythonScriptController::script_onMouseButtonMiddle(const int posX,const int
 {
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
                                                "PythonScriptController_onMouseButtonMiddle", this);
-    PythonEnvironment::gil lock;
+    PythonEnvironment::gil lock(__func__);
     PyObject *pyPressed = pressed? Py_True : Py_False;
     SP_CALL_MODULEFUNC(m_Func_onMouseButtonMiddle, "(iiO)", posX,posY,pyPressed)
 }
@@ -356,7 +356,7 @@ void PythonScriptController::script_onMouseWheel(const int posX,const int posY,c
 {
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
                                                "PythonScriptController_onMouseWheel", this);
-    PythonEnvironment::gil lock;
+    PythonEnvironment::gil lock(__func__);
     SP_CALL_MODULEFUNC(m_Func_onMouseWheel, "(iii)", posX,posY,delta)
 }
 
@@ -365,7 +365,7 @@ void PythonScriptController::script_onBeginAnimationStep(const double dt)
 {
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
                                                "PythonScriptController_onBeginAnimationStep", this);
-    PythonEnvironment::gil lock;
+    PythonEnvironment::gil lock(__func__);
     SP_CALL_MODULEFUNC(m_Func_onBeginAnimationStep, "(d)", dt)
 }
 
@@ -373,25 +373,25 @@ void PythonScriptController::script_onEndAnimationStep(const double dt)
 {
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
                                                "PythonScriptController_onEndAnimationStep", this);
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC(m_Func_onEndAnimationStep, "(d)", dt)
 }
 
 void PythonScriptController::script_storeResetState()
 {
-    PythonEnvironment::gil lock;
+    PythonEnvironment::gil lock(__func__);
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_storeResetState)
 }
 
 void PythonScriptController::script_reset()
 {
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_reset)
 }
 
 void PythonScriptController::script_cleanup()
 {
-    PythonEnvironment::gil lock;    
+    PythonEnvironment::gil lock(__func__);    
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_cleanup)
 }
 
@@ -399,7 +399,7 @@ void PythonScriptController::script_onGUIEvent(const char* controlID, const char
 {
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
                                                "PythonScriptController_onGUIEvent", this);
-    PythonEnvironment::gil lock;
+    PythonEnvironment::gil lock(__func__);
     SP_CALL_MODULEFUNC(m_Func_onGUIEvent,"(sss)",controlID,valueName,value);
 }
 
@@ -407,7 +407,7 @@ void PythonScriptController::script_onScriptEvent(core::objectmodel::ScriptEvent
 {
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
                                                "PythonScriptController_onScriptEvent", this);
-    PythonEnvironment::gil lock;
+    PythonEnvironment::gil lock(__func__);
     PythonScriptEvent *pyEvent = static_cast<PythonScriptEvent*>(event);
     SP_CALL_MODULEFUNC(m_Func_onScriptEvent,"(OsO)",
                        sofa::PythonFactory::toPython(pyEvent->getSender().get()),
@@ -426,7 +426,7 @@ void PythonScriptController::script_draw(const core::visual::VisualParams*)
 {
     ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
                                                "PythonScriptController_draw", this);
-    PythonEnvironment::gil lock;
+    PythonEnvironment::gil lock(__func__);
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_draw);
 }
 

--- a/applications/plugins/SofaPython/PythonScriptController.cpp
+++ b/applications/plugins/SofaPython/PythonScriptController.cpp
@@ -144,6 +144,8 @@ PythonScriptController::~PythonScriptController()
 
 
 void PythonScriptController::setInstance(PyObject* instance) {
+    PythonEnvironment::gil lock;
+    
     // "trust me i'm an engineer"
     if( m_ScriptControllerInstance ) {
         Py_DECREF( m_ScriptControllerInstance );
@@ -187,6 +189,7 @@ void PythonScriptController::refreshBinding()
 
 bool PythonScriptController::isDerivedFrom(const std::string& name, const std::string& module)
 {
+    PythonEnvironment::gil lock;    
     PyObject* moduleDict = PyModule_GetDict(PyImport_AddModule(module.c_str()));
     PyObject* controllerClass = PyDict_GetItemString(moduleDict, name.c_str());
 
@@ -195,6 +198,7 @@ bool PythonScriptController::isDerivedFrom(const std::string& name, const std::s
 
 void PythonScriptController::loadScript()
 {
+    PythonEnvironment::gil lock;        
     if(m_doAutoReload.getValue())
     {
         FileMonitor::addFile(m_filename.getFullPath(), m_filelistener) ;
@@ -247,9 +251,13 @@ void PythonScriptController::doLoadScript()
 
 void PythonScriptController::script_onIdleEvent(const IdleEvent* /*event*/)
 {
+    
     FileMonitor::updates(0);
 
-    SP_CALL_MODULEFUNC_NOPARAM(m_Func_onIdle) ;
+    {
+        PythonEnvironment::gil lock;
+        SP_CALL_MODULEFUNC_NOPARAM(m_Func_onIdle) ;
+    }
 
     // Flush the console to avoid the sys.stdout.flush() in each script function.
     std::cout.flush() ;
@@ -258,6 +266,7 @@ void PythonScriptController::script_onIdleEvent(const IdleEvent* /*event*/)
 
 void PythonScriptController::script_onLoaded(Node *node)
 {
+    PythonEnvironment::gil lock;    
     SP_CALL_MODULEFUNC(m_Func_onLoaded, "(O)", sofa::PythonFactory::toPython(node))
 }
 
@@ -279,102 +288,130 @@ void PythonScriptController::parse(sofa::core::objectmodel::BaseObjectDescriptio
 
 void PythonScriptController::script_createGraph(Node *node)
 {
+    PythonEnvironment::gil lock;    
     SP_CALL_MODULEFUNC(m_Func_createGraph, "(O)", sofa::PythonFactory::toPython(node))
 }
 
 void PythonScriptController::script_initGraph(Node *node)
 {
+    PythonEnvironment::gil lock;    
     SP_CALL_MODULEFUNC(m_Func_initGraph, "(O)", sofa::PythonFactory::toPython(node))
 }
 
 void PythonScriptController::script_bwdInitGraph(Node *node)
 {
+    PythonEnvironment::gil lock;    
     SP_CALL_MODULEFUNC(m_Func_bwdInitGraph, "(O)", sofa::PythonFactory::toPython(node))
 }
 
 bool PythonScriptController::script_onKeyPressed(const char c)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_onKeyPressed", this);
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
+                                               "PythonScriptController_onKeyPressed", this);
     bool b = false;
-    SP_CALL_MODULEBOOLFUNC(m_Func_onKeyPressed,"(c)", c)
-            return b;
+    PythonEnvironment::gil lock;    
+    SP_CALL_MODULEBOOLFUNC(m_Func_onKeyPressed,"(c)", c);
+    return b;
 }
 
 bool PythonScriptController::script_onKeyReleased(const char c)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_onKeyReleased", this);
+
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
+                                               "PythonScriptController_onKeyReleased", this);
     bool b = false;
-    SP_CALL_MODULEBOOLFUNC(m_Func_onKeyReleased,"(c)", c)
-            return b;
+    PythonEnvironment::gil lock;    
+    SP_CALL_MODULEBOOLFUNC(m_Func_onKeyReleased,"(c)", c);
+    return b;
 }
 
 void PythonScriptController::script_onMouseButtonLeft(const int posX,const int posY,const bool pressed)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_onMouseButtonLeft",this);
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
+                                               "PythonScriptController_onMouseButtonLeft",this);
+    PythonEnvironment::gil lock;    
     PyObject *pyPressed = pressed? Py_True : Py_False;
     SP_CALL_MODULEFUNC(m_Func_onMouseButtonLeft, "(iiO)", posX,posY,pyPressed)
 }
 
 void PythonScriptController::script_onMouseButtonRight(const int posX,const int posY,const bool pressed)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_onMouseButtonRight", this);
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
+                                               "PythonScriptController_onMouseButtonRight", this);
+    PythonEnvironment::gil lock;
     PyObject *pyPressed = pressed? Py_True : Py_False;
     SP_CALL_MODULEFUNC(m_Func_onMouseButtonRight, "(iiO)", posX,posY,pyPressed)
 }
 
 void PythonScriptController::script_onMouseButtonMiddle(const int posX,const int posY,const bool pressed)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_onMouseButtonMiddle", this);
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
+                                               "PythonScriptController_onMouseButtonMiddle", this);
+    PythonEnvironment::gil lock;
     PyObject *pyPressed = pressed? Py_True : Py_False;
     SP_CALL_MODULEFUNC(m_Func_onMouseButtonMiddle, "(iiO)", posX,posY,pyPressed)
 }
 
 void PythonScriptController::script_onMouseWheel(const int posX,const int posY,const int delta)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_onMouseWheel", this);
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
+                                               "PythonScriptController_onMouseWheel", this);
+    PythonEnvironment::gil lock;
     SP_CALL_MODULEFUNC(m_Func_onMouseWheel, "(iii)", posX,posY,delta)
 }
 
 
 void PythonScriptController::script_onBeginAnimationStep(const double dt)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_onBeginAnimationStep", this);
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
+                                               "PythonScriptController_onBeginAnimationStep", this);
+    PythonEnvironment::gil lock;
     SP_CALL_MODULEFUNC(m_Func_onBeginAnimationStep, "(d)", dt)
 }
 
 void PythonScriptController::script_onEndAnimationStep(const double dt)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_onEndAnimationStep", this);
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
+                                               "PythonScriptController_onEndAnimationStep", this);
+    PythonEnvironment::gil lock;    
     SP_CALL_MODULEFUNC(m_Func_onEndAnimationStep, "(d)", dt)
 }
 
 void PythonScriptController::script_storeResetState()
 {
+    PythonEnvironment::gil lock;
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_storeResetState)
 }
 
 void PythonScriptController::script_reset()
 {
+    PythonEnvironment::gil lock;    
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_reset)
 }
 
 void PythonScriptController::script_cleanup()
 {
+    PythonEnvironment::gil lock;    
     SP_CALL_MODULEFUNC_NOPARAM(m_Func_cleanup)
 }
 
 void PythonScriptController::script_onGUIEvent(const char* controlID, const char* valueName, const char* value)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_onGUIEvent", this);
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(),
+                                               "PythonScriptController_onGUIEvent", this);
+    PythonEnvironment::gil lock;
     SP_CALL_MODULEFUNC(m_Func_onGUIEvent,"(sss)",controlID,valueName,value);
 }
 
 void PythonScriptController::script_onScriptEvent(core::objectmodel::ScriptEvent* event)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_onScriptEvent", this);
-
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
+                                               "PythonScriptController_onScriptEvent", this);
+    PythonEnvironment::gil lock;
     PythonScriptEvent *pyEvent = static_cast<PythonScriptEvent*>(event);
-    SP_CALL_MODULEFUNC(m_Func_onScriptEvent,"(OsO)",sofa::PythonFactory::toPython(pyEvent->getSender().get()),pyEvent->getEventName().c_str(),pyEvent->getUserData())
+    SP_CALL_MODULEFUNC(m_Func_onScriptEvent,"(OsO)",
+                       sofa::PythonFactory::toPython(pyEvent->getSender().get()),
+                       pyEvent->getEventName().c_str(),pyEvent->getUserData());
 }
 
 
@@ -387,9 +424,10 @@ void PythonScriptController::script_onEvent(core::objectmodel::Event* event) {
 
 void PythonScriptController::script_draw(const core::visual::VisualParams*)
 {
-    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), "PythonScriptController_draw", this);
-
-    SP_CALL_MODULEFUNC_NOPARAM(m_Func_draw)
+    ActivableScopedAdvancedTimer advancedTimer(m_timingEnabled.getValue(), 
+                                               "PythonScriptController_draw", this);
+    PythonEnvironment::gil lock;
+    SP_CALL_MODULEFUNC_NOPARAM(m_Func_draw);
 }
 
 void PythonScriptController::handleEvent(core::objectmodel::Event *event)

--- a/applications/plugins/SofaPython/PythonScriptFunction.cpp
+++ b/applications/plugins/SofaPython/PythonScriptFunction.cpp
@@ -21,11 +21,14 @@
 ******************************************************************************/
 #include "PythonScriptFunction.h"
 
+#include <SofaPython/PythonEnvironment.h>
+
 namespace sofa
 {
 
 namespace core
 {
+
 
 namespace objectmodel
 {
@@ -46,6 +49,7 @@ PythonScriptFunctionParameter::PythonScriptFunctionParameter(PyObject* data, boo
 
 PythonScriptFunctionParameter::~PythonScriptFunctionParameter()
 {
+    simulation::PythonEnvironment::gil lock(__func__);    
     Py_XDECREF(m_pyData);
 }
 
@@ -53,8 +57,10 @@ PythonScriptFunctionResult::PythonScriptFunctionResult() : ScriptFunctionResult(
 	m_own(false),
 	m_pyData(0)
 {
-    if(m_own)
-        Py_XDECREF(m_pyData);
+	if(m_own) {
+        simulation::PythonEnvironment::gil lock(__func__);
+		Py_XDECREF(m_pyData);
+    }
 }
 
 PythonScriptFunctionResult::PythonScriptFunctionResult(PyObject* data, bool own) : ScriptFunctionResult(),
@@ -66,8 +72,10 @@ PythonScriptFunctionResult::PythonScriptFunctionResult(PyObject* data, bool own)
 
 PythonScriptFunctionResult::~PythonScriptFunctionResult()
 {
-    if(m_own)
-        Py_XDECREF(m_pyData);
+	if(m_own) {
+        simulation::PythonEnvironment::gil lock(__func__);
+		Py_XDECREF(m_pyData);
+    }
 }
 
 PythonScriptFunction::PythonScriptFunction(PyObject* pyCallableObject, bool own) : ScriptFunction(),
@@ -79,41 +87,48 @@ PythonScriptFunction::PythonScriptFunction(PyObject* pyCallableObject, bool own)
 
 PythonScriptFunction::~PythonScriptFunction()
 {
-    if(m_own)
-        Py_XDECREF(m_pyCallableObject);
+  if(m_own) {
+    simulation::PythonEnvironment::gil lock(__func__);
+    Py_XDECREF(m_pyCallableObject);
+  }
 }
 
 void PythonScriptFunction::setCallableObject(PyObject* callableObject, bool own)
 {
-    if(m_own)
-        Py_XDECREF(m_pyCallableObject);
+  simulation::PythonEnvironment::gil lock(__func__);          
 
-    m_pyCallableObject = callableObject;
-    m_own = own;
+  if(m_own) {
+      Py_XDECREF(m_pyCallableObject);
+  }
+  m_pyCallableObject = callableObject;
+  m_own = own;
+
 }
 
 
 void PythonScriptFunction::onCall(const ScriptFunctionParameter* parameter, ScriptFunctionResult* result) const
 {
-	if(!m_pyCallableObject)
+	if(!m_pyCallableObject) {
 		return;
+    }
 
+    simulation::PythonEnvironment::gil lock(__func__);
+    
 	const PythonScriptFunctionParameter* pythonScriptParameter = dynamic_cast<const PythonScriptFunctionParameter*>(parameter);
 	PythonScriptFunctionResult* pythonScriptResult = dynamic_cast<PythonScriptFunctionResult*>(result);
 
 	PyObject* pyParameter = 0;
-	if(pythonScriptParameter)
+	if(pythonScriptParameter) {
 		pyParameter = pythonScriptParameter->data();
-
+    }
+    
 	PyObject* pyResult = PyObject_CallObject(m_pyCallableObject, pyParameter);
-
-    if(!pyResult)
-	{
-		SP_MESSAGE_EXCEPTION("in PythonScriptFunction: python function call failed")
-		PyErr_Print();
-	}
-	else if(pythonScriptResult)
+	if(!pyResult) {
+		SP_MESSAGE_EXCEPTION("in PythonScriptFunction: python function call failed");
+        PyErr_Print();
+	} else if(pythonScriptResult) {
 		pythonScriptResult->setData(pyResult, true);
+    }
 }
 
 } // namespace objectmodel

--- a/applications/plugins/SofaPython/PythonScriptFunction.h
+++ b/applications/plugins/SofaPython/PythonScriptFunction.h
@@ -36,6 +36,8 @@ namespace core
 namespace objectmodel
 {
 
+// mtournier: wtf is this supposed to do?
+// mtournier: wtf is this doing in sofa::core?
 class SOFA_SOFAPYTHON_API PythonScriptFunctionParameter : public ScriptFunctionParameter
 {
 public:

--- a/applications/plugins/SofaPython/PythonVisitor.cpp
+++ b/applications/plugins/SofaPython/PythonVisitor.cpp
@@ -19,6 +19,7 @@ PythonVisitor::PythonVisitor(const core::ExecParams* params, PyObject *pyVisitor
 
 Visitor::Result PythonVisitor::processNodeTopDown(simulation::Node* node)
 {
+    PythonEnvironment::gil lock(__func__);
     PyObject *res = PyObject_CallMethod(m_PyVisitor,const_cast<char*>("processNodeTopDown"),const_cast<char*>("(O)"),sofa::PythonFactory::toPython(node));
     if( !res || !PyBool_Check(res) )
     {
@@ -34,12 +35,14 @@ Visitor::Result PythonVisitor::processNodeTopDown(simulation::Node* node)
 
 void PythonVisitor::processNodeBottomUp(simulation::Node* node)
 {
+    PythonEnvironment::gil lock(__func__);    
     PyObject *res = PyObject_CallMethod(m_PyVisitor,const_cast<char*>("processNodeBottomUp"),const_cast<char*>("(O)"),sofa::PythonFactory::toPython(node));
     Py_XDECREF(res);
 }
 
 bool PythonVisitor::treeTraversal(TreeTraversalRepetition& repeat)
 {
+    PythonEnvironment::gil lock(__func__);        
     PyObject *res = PyObject_CallMethod(m_PyVisitor,const_cast<char*>("treeTraversal"),const_cast<char*>("()"));
 
 

--- a/applications/plugins/SofaPython/SceneLoaderPY.cpp
+++ b/applications/plugins/SofaPython/SceneLoaderPY.cpp
@@ -114,6 +114,7 @@ void SceneLoaderPY::loadSceneWithArguments(const char *filename,
                                            const std::vector<std::string>& arguments,
                                            Node::SPtr* root_out)
 {
+    PythonEnvironment::gil lock(__func__);    
     if(!OurHeader.empty() && 0 != PyRun_SimpleString(OurHeader.c_str()))
     {
         SP_MESSAGE_ERROR( "header script run error." );
@@ -172,6 +173,7 @@ void SceneLoaderPY::loadSceneWithArguments(const char *filename,
 
 bool SceneLoaderPY::loadTestWithArguments(const char *filename, const std::vector<std::string>& arguments)
 {
+    PythonEnvironment::gil lock(__func__);    
     if(!OurHeader.empty() && 0 != PyRun_SimpleString(OurHeader.c_str()))
     {
         SP_MESSAGE_ERROR( "header script run error." )

--- a/applications/plugins/SofaPython/ScriptFunction.h
+++ b/applications/plugins/SofaPython/ScriptFunction.h
@@ -54,6 +54,8 @@ public:
 
 };
 
+
+// mtournier: wtf is this supposed to be/do?
 class SOFA_SOFAPYTHON_API ScriptFunction
 {
 protected:

--- a/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
+++ b/applications/plugins/SofaPython/SofaPython_test/PythonFactory_test.cpp
@@ -85,6 +85,7 @@ protected:
     {
         /// ADDING new component in the python Factory
         /// of course its binding must be defined!
+        simulation::PythonEnvironment::gil lock(__func__);
         SP_ADD_CLASS_IN_FACTORY( ExternalComponent, sofa::ExternalComponent )
     }
 

--- a/applications/plugins/image/initImage.cpp
+++ b/applications/plugins/image/initImage.cpp
@@ -56,6 +56,8 @@ void initExternalModule()
 #ifdef SOFA_HAVE_SOFAPYTHON
         if( PythonFactory::s_sofaPythonModule ) // add the module only if the Sofa module exists (SofaPython is loaded)
         {
+            simulation::PythonEnvironment::gil lock(__func__);
+            
             // adding new bindings for Data<Image<T>>
             SP_ADD_CLASS_IN_FACTORY(ImageCData,sofa::core::objectmodel::Data<sofa::defaulttype::ImageC>)
             SP_ADD_CLASS_IN_FACTORY(ImageUCData,sofa::core::objectmodel::Data<sofa::defaulttype::ImageUC>)


### PR DESCRIPTION
(this is a mirror for #326, which @ocarre need for multithreading)

Please don't merge it too soon, I'd like it to stage here for a while to make sure we don't break anything.

*EDIT: apparently the above was not quite visible enough, lemme restate that:*

# Please don't merge it too soon, I'd like it to stage here for a while to make sure we don't break anything.

**TL;DR:** There should be no unprotected python code in sofa except in extension code.

Any code like this:

```c++
void my_function(...) {
   // ...
   PySomething_Something(...);
}
```

Should now be GIL-protected as follows:

```c++
void my_function(...) {
   // ...
   // the lock runs until the end of scope
   sofa::simulation::PythonEnvironment::gil lock;
   PySomething_Something(...);
}
```

Or even better yet: don't use naked python calls and use the `PythonEnvironment` API instead. You may also temporarily release the GIL while doing a costly/blocking c++ operation as follows:

```c++
void my_function_that_already_owns_the_gil(...) {
   // ...
   // unlocks the GIL until the end of scope
   sofa::simulation::PythonEnvironment::no_gil unlock;
   // ...
}
```

I tried looking for all python calls in the codebase, but I may have missed some.

# Changelog

- added `PythonEnvironment::gil` RAII for scoped acquisition of the GIL
- added `PythonEnvironment::no_gil` RAII for scoped release of the GIL
- GIL-protected most (all?) python calls with the above (except in extension code)


______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
